### PR TITLE
Fix complex breakpoint condition template.

### DIFF
--- a/Cheat Engine/frmBreakpointConditionUnit.lfm
+++ b/Cheat Engine/frmBreakpointConditionUnit.lfm
@@ -122,7 +122,7 @@ object frmBreakpointCondition: TfrmBreakpointCondition
           '--Changing them has no effect though'
           '--Note: Keep in mind hexadecimal values start with 0x'
           ''
-          'return (conditon) --return a non-zero value if you want to break'
+          'return (conditon) --return true if you want to break, false to not break'
         )
         ScrollBars = ssBoth
         TabOrder = 0


### PR DESCRIPTION
If you return 0, as the comment suggested, CE will still break because Lua considers 0 to be true.